### PR TITLE
Updates for Ubuntu gatttool and connect

### DIFF
--- a/pygatt/pygatt.py
+++ b/pygatt/pygatt.py
@@ -54,9 +54,10 @@ class BluetoothLeDevice(object):
         thread.start_new_thread(self.run, ())
 
     def connect(self, timeout=5.0):
-        self.con.sendline('connect')
         try:
-            self.con.expect('\[CON\]', timeout)
+            with self.connection_lock:
+                self.con.sendline('connect')
+                self.con.expect('\[CON\]', timeout)
         except pexpect.TIMEOUT:
             raise BluetoothLeError("Unable to connect to device")
 


### PR DESCRIPTION
gatttool on ubuntu (14.04) has slightly different output than pygatt was configured for. This update allows it to connect and read handle values and hopefully be backwards-compatible.

It also adds more control over when you connect to the remote BLE device, and for setting a timeout value.
