### PR TITLE
Support unicode UUID characteristic when converting to handle

### DIFF
--- a/pygatt/device.py
+++ b/pygatt/device.py
@@ -145,7 +145,7 @@ class BLEDevice(object):
         :type uuid: str
         :return: None if the UUID was not found.
         """
-        if isinstance(char_uuid, str):
+        if isinstance(char_uuid, basestring):
             char_uuid = UUID(char_uuid)
         log.debug("Looking up handle for characteristic %s", char_uuid)
         if char_uuid not in self._characteristics:

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -58,3 +58,7 @@ class BLEDeviceTest(unittest.TestCase):
         self.device.receive_notification(
             TestBLEDevice.EXPECTED_HANDLE + 1, value)
         ok_(not callback.called)
+
+    def test_unicode_get_handle(self):
+        for chars in self.device.discover_characteristics().values():
+            self.device.get_handle(unicode(chars.uuid))


### PR DESCRIPTION
gatttool backend returns unicode UUID's in discover_characteristics()["foo"].uuid
converting these back to handles with get_handle fails isinstance check as uuid is not
of str type. Checking instance type against basestring solves this problem.