### PR TITLE
Add gattool output to error log to aid with debugging.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -61,6 +61,20 @@ finally:
 Note that not all backends support connecting to more than 1 device at at time,
 so calling `BLEBackend.connect` again may terminate existing connections.
 
+## Debugging
+
+While debugging software using pygatt, it is often useful to see what's
+happening inside the library. You can enable debugging logging and have it
+printed to your terminal with this code:
+
+```
+import pygatt
+import logging
+
+logging.basicConfig()
+logging.getLogger('pygatt').setLevel(logging.DEBUG)
+```
+
 ## Authors
 
 - Jeff Rowberg @jrowberg https://github.com/jrowberg/bglib

--- a/pygatt/backends/gatttool/gatttool.py
+++ b/pygatt/backends/gatttool/gatttool.py
@@ -296,10 +296,17 @@ class GATTToolBackend(BLEBackend):
                         self._handle_notification_string(self._con.after)
                     elif matched_pattern_index == 3:
                         if self._running.is_set():
-                            log.info("Disconnected")
+                            log.error("Device disconnected unexpectedly "
+                                      "(gatttool output: %s)" % self._con.after)
+                            raise NotConnectedError(
+                                "Device disconnected unexpectedly",
+                                gatttool_output=(
+                                    self._con.before + self._con.after))
                 except pexpect.TIMEOUT:
                     raise NotificationTimeout(
-                        "Timed out waiting for a notification")
+                        "Timed out waiting for a notification, "
+                        "device may have disconnected",
+                        gatttool_output=self._con.before)
 
     def _handle_notification_string(self, msg):
         hex_handle, _, hex_value = msg.strip().split()[3:]

--- a/pygatt/exceptions.py
+++ b/pygatt/exceptions.py
@@ -17,7 +17,9 @@ class NotConnectedError(BLEError):
 
 
 class NotificationTimeout(BLEError):
-    pass
+    def __init__(self, msg, gatttool_output=None):
+        super(NotificationTimeout, self).__init__(msg)
+        self.gatttool_output = gatttool_output
 
 
 class NoResponseError(BLEError):


### PR DESCRIPTION
This also mentions how to enable debug logging to the console in the
README, and attaches the gatttool output to NotConnectedError exceptions.

Fixes #24