### PR TITLE
PR #45 with reused code, name change

### DIFF
--- a/pygatt/backends/bgapi/bgapi.py
+++ b/pygatt/backends/bgapi/bgapi.py
@@ -125,7 +125,7 @@ class BGAPIBackend(BLEBackend):
         if self._running and self._running.is_set():
             self.stop()
 
-        self._ser = serial.Serial(self._serial_port, baudrate=256000,
+        self._ser = serial.Serial(self._serial_port, baudrate=115200,
                                   timeout=0.25)
         self._receiver = threading.Thread(target=self._receive)
         self._receiver.daemon = True

--- a/pygatt/backends/bgapi/bgapi.py
+++ b/pygatt/backends/bgapi/bgapi.py
@@ -247,7 +247,7 @@ class BGAPIBackend(BLEBackend):
 
         self.expect(ResponsePacketType.gap_discover)
 
-        log.info("Pausing for for %ds to allow scan to complete", timeout)
+        log.info("Pausing for %ds to allow scan to complete", timeout)
         time.sleep(timeout)
 
         log.info("Stopping scan")
@@ -259,7 +259,8 @@ class BGAPIBackend(BLEBackend):
             devices.append({
                 'address': address,
                 'name': info.name,
-                'rssi': info.rssi
+                'rssi': info.rssi,
+                'packet_data': info.packet_data
             })
         log.info("Discovered %d devices: %s", len(devices), devices)
         self._devices_discovered = {}

--- a/pygatt/backends/bgapi/device.py
+++ b/pygatt/backends/bgapi/device.py
@@ -72,8 +72,11 @@ class BGAPIBLEDevice(BLEDevice):
         raise BGAPIError("get rssi failed")
 
     @connection_required
-    def char_read(self, uuid):
-        handle = self.get_handle(uuid)
+    def char_read(self, uuid, timeout=None):
+        return self.char_read_handle(self.get_handle(uuid), timeout=timeout)
+
+    @connection_required
+    def char_read_handle(self, handle, timeout=None):
         log.info("Reading characteristic at handle %d", handle)
         self._backend.send_command(
             CommandBuilder.attclient_read_by_handle(
@@ -82,32 +85,13 @@ class BGAPIBLEDevice(BLEDevice):
         self._backend.expect(ResponsePacketType.attclient_read_by_handle)
         matched_packet_type, response = self._backend.expect_any(
             [EventPacketType.attclient_attribute_value,
-             EventPacketType.attclient_procedure_completed])
+             EventPacketType.attclient_procedure_completed], timeout=timeout)
         # TODO why not just expect *only* the attribute value response, then it
         # would time out and raise an exception if allwe got was the 'procedure
         # completed' response?
         if matched_packet_type != EventPacketType.attclient_attribute_value:
             raise BGAPIError("Unable to read characteristic")
         return bytearray(response['value'])
-
-    @connection_required
-    def handle_read(self, handle):
-        log.info("Reading characteristic at handle %d", handle)
-        self._backend.send_command(
-            CommandBuilder.attclient_read_by_handle(
-                self._handle, handle))
-
-        self._backend.expect(ResponsePacketType.attclient_read_by_handle)
-        # 2 s timeout
-        matched_packet_type, response = self._backend.expect_any(
-            [EventPacketType.attclient_attribute_value,
-             EventPacketType.attclient_procedure_completed], 2)
-        # TODO why not just expect *only* the attribute value response, then it
-        # would time out and raise an exception if all we got was the 'procedure
-        # completed' response?
-        if matched_packet_type != EventPacketType.attclient_attribute_value:
-            raise BGAPIError("Unable to read characteristic")
-        return response['value']
 
     @connection_required
     def char_write_handle(self, char_handle, value, wait_for_response=False):


### PR DESCRIPTION
This takes the work done in #45 by @3sigma and:

* Renames the new function to match the convention used for writing and in `gatttool` - `char_read_handle`
* Reduce duplication in the new function by having char_read simply look up the UUID, then call this function.