### PR TITLE
Store characteristics on GATTTool device so they aren't requested twice.

### DIFF
--- a/pygatt/backends/gatttool/device.py
+++ b/pygatt/backends/gatttool/device.py
@@ -48,4 +48,5 @@ class GATTToolBLEDevice(BLEDevice):
 
     @connection_required
     def discover_characteristics(self):
-        return self._backend.discover_characteristics(self)
+        self._characteristics = self._backend.discover_characteristics(self)
+        return self._characteristics

--- a/pygatt/device.py
+++ b/pygatt/device.py
@@ -181,7 +181,6 @@ class BLEDevice(object):
             char_uuid = UUID(char_uuid)
         log.debug("Looking up handle for characteristic %s", char_uuid)
         if char_uuid not in self._characteristics:
-            # TODO need to expose discovering characterstics via BLEDevice
             self._characteristics = self.discover_characteristics()
 
         characteristic = self._characteristics.get(char_uuid)


### PR DESCRIPTION
Due to one-device-at-a-time limitation on the GATTTool backend, the
query for characteristics actually happens in the backend class. The
list was being stored on the backend but not shared with the device
instance, so if you called any other function that needed to find the
handle for a UUID (e.g. subscribing or reading or writing), it would
query for the characteristics again.

This makes sure the characteristic are also copied to the device
instance so the device can read from the cache.