### PR TITLE
Python 3 compatibility fixes

### DIFF
--- a/pygatt/backends/gatttool/gatttool.py
+++ b/pygatt/backends/gatttool/gatttool.py
@@ -23,6 +23,15 @@ from .device import GATTToolBLEDevice
 
 log = logging.getLogger(__name__)
 
+if hasattr(bytes, 'fromhex'):
+    # Python 3.
+    def _hex_value_parser(x):
+        return bytearray.fromhex(x.decode('utf8'))
+else:
+    # Python 2.7
+    def _hex_value_parser(x):
+        return bytearray.fromhex(x)
+
 
 def at_most_one_device(func):
     """Every connection-specific function on the backend takes an instance of
@@ -408,7 +417,7 @@ class GATTToolBackend(BLEBackend):
 
         hex_handle, _, hex_values = split_msg[3:]
         handle = int(hex_handle, 16)
-        values = bytearray(hex_values.replace(" ", "").decode("hex"))
+        values = _hex_value_parser(hex_values)
         if self._connected_device is not None:
             self._connected_device.receive_notification(handle, values)
 

--- a/pygatt/device.py
+++ b/pygatt/device.py
@@ -8,6 +8,11 @@ from uuid import UUID
 
 from . import exceptions
 
+try:
+    string_type = basestring
+except NameError:
+    string_type = str
+
 log = logging.getLogger(__name__)
 
 
@@ -177,7 +182,7 @@ class BLEDevice(object):
         :type uuid: str
         :return: None if the UUID was not found.
         """
-        if isinstance(char_uuid, basestring):
+        if isinstance(char_uuid, string_type):
             char_uuid = UUID(char_uuid)
         log.debug("Looking up handle for characteristic %s", char_uuid)
         if char_uuid not in self._characteristics:


### PR DESCRIPTION
When using pygatt with the gatttool backend in Python 3, the `isinstance(s, basestring)` fails. Replacing with a Py2/Py3 compatible solution.

Also needed to change the hex to bytearray solution in  `GATTToolBackend._handle_notification_string` to accommodate Python 3 usage. I rebuilt it so it works in both Python 2.7 and Python 3 (not in Python 2.6 however; can address that if you deem necessary) and also yielding a speedup in Python 2.7 compared to the old one:

```python
In [1]: hex_value_parser = lambda x: bytearray.fromhex(x)

In [2]: old_hex_value_parser = lambda x: bytearray(x.replace(" ", "").decode("hex"))

In [3]: %timeit hex_value_parser("01 80 00 00")
The slowest run took 10.68 times longer than the fastest. This could mean that an intermediate result is being cached.
1000000 loops, best of 3: 268 ns per loop

In [4]: %timeit old_hex_value_parser("01 80 00 00")
The slowest run took 8.28 times longer than the fastest. This could mean that an intermediate result is being cached.
1000000 loops, best of 3: 979 ns per loop
```