### PR TITLE
Remember auto-detected BLED112 port name before reset

### DIFF
--- a/pygatt/backends/bgapi/bgapi.py
+++ b/pygatt/backends/bgapi/bgapi.py
@@ -120,8 +120,8 @@ class BGAPIBackend(BLEBackend):
             product_id=BLED112_PRODUCT_ID)
         if len(detected_devices) == 0:
             raise BGAPIError("Unable to auto-detect BLED112 serial port")
-
-        return detected_devices[0].port_name
+        self._serial_port = detected_devices[0].port_name
+        return self._serial_port
 
     def _open_serial_port(self):
         """


### PR DESCRIPTION
By setting _serial_port in the BGAPI backend, pygatt doesn't have to re-detect the BLED112 when resetting the state.
This commit seems to fix issue #71