### PR TITLE
Correct device name regular expression

### DIFF
--- a/pygatt/backends/gatttool/gatttool.py
+++ b/pygatt/backends/gatttool/gatttool.py
@@ -299,7 +299,7 @@ class GATTToolBackend(BLEBackend):
                     raise BLEError("Enable passwordless sudo for 'hcitool' "
                                    "before scanning")
                 match = re.match(
-                    r'(([0-9A-Fa-f][0-9A-Fa-f]:?){6}) (\(?[\w]+\)?)', line)
+                    r'(([0-9A-Fa-f][0-9A-Fa-f]:?){6}) (\(?.+\)?)', line)
 
                 if match is not None:
                     address = match.group(1)


### PR DESCRIPTION
A Bluetooth device name can contain any UTF-8 character
Fixes #86