### PR TITLE
Using the same hci device for hcitool and gatttool commands

### DIFF
--- a/pygatt/backends/gatttool/gatttool.py
+++ b/pygatt/backends/gatttool/gatttool.py
@@ -290,7 +290,7 @@ class GATTToolBackend(BLEBackend):
         terminate cleanly, and may leave your Bluetooth adapter in a bad state.
         """
 
-        cmd = 'hcitool lescan'
+        cmd = 'hcitool -i %s lescan' % self.hci_device
         if run_as_root:
             cmd = 'sudo %s' % cmd
 


### PR DESCRIPTION
When using two or more devices hcitool is set to use the default device instead of the device passed in hci_device used by gatttool.