### PR TITLE
Multiple callbacks

### DIFF
--- a/pygatt/backends/gatttool/device.py
+++ b/pygatt/backends/gatttool/device.py
@@ -56,3 +56,9 @@ class GATTToolBLEDevice(BLEDevice):
     def discover_characteristics(self):
         self._characteristics = self._backend.discover_characteristics(self)
         return self._characteristics
+
+    def register_disconnect_callback(self, callback):
+        self._backend._receiver.register_callback("disconnected", callback)
+
+    def remove_disconnect_callback(self, callback):
+        self._backend._receiver.remove_callback("disconnected", callback)

--- a/pygatt/backends/gatttool/gatttool.py
+++ b/pygatt/backends/gatttool/gatttool.py
@@ -23,6 +23,8 @@ from pygatt.backends import BLEBackend, Characteristic, BLEAddressType
 from pygatt.backends.backend import DEFAULT_CONNECT_TIMEOUT_S
 from .device import GATTToolBLEDevice
 
+DEFAULT_RECONNECT_DELAY = 1.0
+
 log = logging.getLogger(__name__)
 
 if hasattr(bytes, 'fromhex'):
@@ -207,6 +209,8 @@ class GATTToolBackend(BLEBackend):
         self._running = threading.Event()
         self._address = None
         self._send_lock = threading.Lock()
+        self._auto_reconnect = False
+        self._reconnecting = False
 
     def sendline(self, command):
         """
@@ -365,10 +369,11 @@ class GATTToolBackend(BLEBackend):
         return []
 
     def connect(self, address, timeout=DEFAULT_CONNECT_TIMEOUT_S,
-                address_type=BLEAddressType.public):
+                address_type=BLEAddressType.public, auto_reconnect=False):
         log.info('Connecting to %s with timeout=%s', address, timeout)
         self.sendline('sec-level low')
         self._address = address
+        self._auto_reconnect = auto_reconnect
 
         try:
             cmd = 'connect {0} {1}'.format(self._address, address_type.name)
@@ -403,13 +408,45 @@ class GATTToolBackend(BLEBackend):
         log.info("Removed bonds for %s", address)
 
     def _disconnect(self, event):
-        try:
-            self.disconnect(self._connected_device)
-        except NotConnectedError:
-            pass
+        if self._connected_device is not None and self._auto_reconnect:
+
+            # this is called as a callback from the pexpect thread
+            # the reconnection process has to be started in parallel, otherwise
+            # the call is never finished
+            log.info("Connection to %s lost. Reconnecting...", self._address)
+            reconnect_thread = threading.Thread(target=self.reconnect,
+                                                args=(self._connected_device, ))
+            reconnect_thread.start()
+        else:
+            try:
+                self.disconnect(self._connected_device)
+            except NotConnectedError:
+                pass
+
+    @at_most_one_device
+    def reconnect(self, timeout=DEFAULT_CONNECT_TIMEOUT_S):
+        while self._auto_reconnect:
+            log.info("Connecting to %s with timeout=%s", self._address,
+                     timeout)
+            try:
+                cmd = "connect"
+                with self._receiver.event("connect", timeout):
+                    self.sendline(cmd)
+                # reenable all notifications
+                self._connected_device.resubscribe_all()
+                log.info("Connection to %s reestablished.")
+                break  # finished reconnecting
+            except NotificationTimeout:
+                message = ("Timed out connecting to {0} after {1} seconds. "
+                           "Retrying in {2} seconds".format(
+                                self._address, timeout,
+                                DEFAULT_RECONNECT_DELAY))
+                log.info(message)
+                time.sleep(DEFAULT_RECONNECT_DELAY)
 
     @at_most_one_device
     def disconnect(self, *args, **kwargs):
+        self._auto_reconnect = False  # disables any running reconnection
         if not self._receiver.is_set("disconnected"):
             self.sendline('disconnect')
         self._connected_device = None

--- a/pygatt/backends/gatttool/gatttool.py
+++ b/pygatt/backends/gatttool/gatttool.py
@@ -103,7 +103,7 @@ class GATTToolReceiver(threading.Thread):
             event["before"] = None
             event["after"] = None
             event["match"] = None
-            event["callback"] = None
+            event["callback"] = []
 
     def run(self):
         items = sorted(itertools.chain.from_iterable(
@@ -128,8 +128,8 @@ class GATTToolReceiver(threading.Thread):
             event["after"] = self._connection.after
             event["match"] = self._connection.match
             event["event"].set()
-            if event["callback"]:
-                event["callback"](event)
+            for clb in event["callback"]:
+                clb(event)
         log.info("Listener thread finished")
 
     def clear(self, event):
@@ -153,7 +153,15 @@ class GATTToolReceiver(threading.Thread):
         Call the callback function when event happens. Event wrapper
         is passed as argument.
         """
-        self._event_vector[event]["callback"] = callback
+        self._event_vector[event]["callback"].append(callback)
+
+    def remove_callback(self, event, callback):
+        """
+        Remove a registered callback, so it is no longer called when an
+        event happens.
+        """
+        if callback in self._event_vector[event]["callback"]:
+            self._event_vector[event]["callback"].remove(callback)
 
     def last_value(self, event, value_type):
         """

--- a/tests/gatttool/test_backend.py
+++ b/tests/gatttool/test_backend.py
@@ -50,6 +50,12 @@ class GATTToolBackendTests(unittest.TestCase):
         ok_(device is not None)
 
     def test_disconnect_callback(self):
+        # Just keep saying we got the "Disconnected" response
+        def rate_limited_expect_d(*args, **kwargs):
+                time.sleep(0.001)
+                # hard code the "Disconnected" event
+                return 1
+
         mock_callback = MagicMock()
         address = "11:22:33:44:55:66"
         device = self.backend.connect(address)
@@ -58,6 +64,11 @@ class GATTToolBackendTests(unittest.TestCase):
             device._backend._receiver._event_vector[
                 "disconnected"]["callback"],
             True)
+
+        self.spawn.return_value.expect.side_effect = rate_limited_expect_d
+        time.sleep(0.1)
+        ok_(mock_callback.called)
+
         device.remove_disconnect_callback(mock_callback)
         eq_(mock_callback not in
             device._backend._receiver._event_vector[

--- a/tests/gatttool/test_backend.py
+++ b/tests/gatttool/test_backend.py
@@ -49,6 +49,24 @@ class GATTToolBackendTests(unittest.TestCase):
         device = self.backend.connect(address)
         ok_(device is not None)
 
+    def test_disconnect_callback(self):
+        mock_callback = MagicMock()
+        address = "11:22:33:44:55:66"
+        device = self.backend.connect(address)
+        device.register_disconnect_callback(mock_callback)
+        eq_(mock_callback in
+            device._backend._receiver._event_vector[
+                "disconnected"]["callback"],
+            True)
+        device.remove_disconnect_callback(mock_callback)
+        eq_(mock_callback not in
+            device._backend._receiver._event_vector[
+                "disconnected"]["callback"],
+            True)
+        eq_(len(device._backend._receiver._event_vector[
+                "disconnected"]["callback"]) > 0,
+            True)
+
     def test_single_byte_notification(self):
         event = {
             'after': "Notification handle = 0x0024 value: 64".encode("utf8")

--- a/tests/gatttool/test_backend.py
+++ b/tests/gatttool/test_backend.py
@@ -77,6 +77,71 @@ class GATTToolBackendTests(unittest.TestCase):
         eq_(len(device._backend._receiver._event_vector[
                 "disconnected"]["callback"]) > 0,
             True)
+        
+    def test_auto_reconnect_call(self):
+        # Just keep saying we got the "Disconnected" response
+        def rate_limited_expect_d(*args, **kwargs):
+            time.sleep(0.001)
+            # hard code the "Disconnected" event
+            return 1
+
+        address = "11:22:33:44:55:66"
+        device = self.backend.connect(address, auto_reconnect=True)
+        device._backend.reconnect = MagicMock()
+        self.spawn.return_value.expect.side_effect = rate_limited_expect_d
+        time.sleep(0.1)
+        ok_(device._backend.reconnect.called)
+
+    def test_no_reconnect_default(self):
+        # Just keep saying we got the "Disconnected" response
+        def rate_limited_expect_d(*args, **kwargs):
+            time.sleep(0.001)
+            # hard code the "Disconnected" event
+            return 1
+
+        address = "11:22:33:44:55:66"
+        device = self.backend.connect(address)
+        device._backend.reconnect = MagicMock()
+        self.spawn.return_value.expect.side_effect = rate_limited_expect_d
+        time.sleep(0.1)
+        ok_(not device._backend.reconnect.called)
+
+    def test_no_reconnect_disconnect(self):
+        # Just keep saying we got the "Disconnected" response
+        def rate_limited_expect_d(*args, **kwargs):
+            time.sleep(0.001)
+            # hard code the "Disconnected" event
+            return 1
+
+        address = "11:22:33:44:55:66"
+        device = self.backend.connect(address, auto_reconnect=True)
+        device._backend.reconnect = MagicMock()
+        device.disconnect()
+        self.spawn.return_value.expect.side_effect = rate_limited_expect_d
+        time.sleep(0.1)
+        ok_(not device._backend.reconnect.called)
+
+    def test_auto_reconnect(self):
+        # Just keep saying we got the "Disconnected" response
+        def rate_limited_expect_d(*args, **kwargs):
+            time.sleep(0.001)
+            # hard code the "Disconnected" event
+            return 1
+
+        # Just keep saying we got the "Connected" response
+        def rate_limited_expect_c(*args, **kwargs):
+            time.sleep(0.001)
+            # hard code the "Connected" event
+            return 3
+
+        address = "11:22:33:44:55:66"
+        device = self.backend.connect(address, auto_reconnect=True)
+        self.spawn.return_value.expect.side_effect = rate_limited_expect_d
+        time.sleep(0.1)
+        device.resubscribe_all = MagicMock()
+        self.spawn.return_value.expect.side_effect = rate_limited_expect_c
+        time.sleep(0.1)
+        ok_(device.resubscribe_all.called)
 
     def test_single_byte_notification(self):
         event = {

--- a/tests/gatttool/test_device.py
+++ b/tests/gatttool/test_device.py
@@ -57,6 +57,15 @@ class GATTToolBLEDeviceTests(unittest.TestCase):
         ok_(self.backend.disconnect.called)
         eq_(self.device, self.backend.disconnect.call_args[0][0])
 
+    def test_additional_disconnect_callback(self):
+        mock_callback = MagicMock()
+        self.device.register_disconnect_callback(mock_callback)
+        self.backend._receiver.register_callback.assert_called_with(
+            "disconnected", mock_callback)
+        self.device.remove_disconnect_callback(mock_callback)
+        self.backend._receiver.remove_callback.assert_called_with(
+            "disconnected", mock_callback)
+
     @raises(NotConnectedError)
     def test_write_after_disconnect(self):
         self.device.disconnect()


### PR DESCRIPTION
These commits enable multiple callbacks for the events tracked in GATTToolReceiver.
For convenience, the GATTToolBLEDevice allows to directly attach new callbacks to the disconnect event.