### PR TITLE
Gatttool auto reconnect

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -21,8 +21,8 @@ works in Linux.
 ## Requirements
 
 * Python 2.7
-* BlueZ 5.5 or greater (with gatttool) - required for the gatttool backend only.
-    * Tested on 5.18, 5.21 and 5.35.
+* BlueZ 5.18 or greater (with gatttool) - required for the gatttool backend only.
+    * Tested on 5.18, 5.21, 5.35 and 5.43
 
 ## Installation
 

--- a/pygatt/backends/gatttool/gatttool.py
+++ b/pygatt/backends/gatttool/gatttool.py
@@ -401,9 +401,9 @@ class GATTToolBackend(BLEBackend):
 
     def _disconnect(self, event):
         if self._auto_reconnect:
-            #this is called as a callback from the pexpect thread
-            #the reconnection process has to be started in parallel, otherwise
-            #the call is never finished
+            # this is called as a callback from the pexpect thread
+            # the reconnection process has to be started in parallel, otherwise
+            # the call is never finished
             log.info("Connection to %s lost. Reconnecting...", self._address)
             reconnect_thread = threading.Thread(target=self.reconnect,
                                                 args=(self._connected_device, ))
@@ -418,18 +418,20 @@ class GATTToolBackend(BLEBackend):
     def reconnect(self, timeout=DEFAULT_CONNECT_TIMEOUT_S):
         while self._auto_reconnect:
             log.info("Connecting to %s with timeout=%s", self._address,
-                        timeout)
+                     timeout)
             try:
                 cmd = "connect"
                 with self._receiver.event("connect", timeout):
                     self.sendline(cmd)
-                self._connected_device.resubscribe_all() # reenable all notifications
+                # reenable all notifications
+                self._connected_device.resubscribe_all()
                 log.info("Connection to %s reestablished.")
-                break # finished reconnecting
+                break  # finished reconnecting
             except NotificationTimeout:
                 message = ("Timed out connecting to {0} after {1} seconds. "
                            "Retrying in {2} seconds".format(
-                                self._address, timeout, DEFAULT_RECONNECT_DELAY))
+                                self._address, timeout,
+                                DEFAULT_RECONNECT_DELAY))
                 log.info(message)
                 time.sleep(DEFAULT_RECONNECT_DELAY)
 

--- a/pygatt/backends/gatttool/gatttool.py
+++ b/pygatt/backends/gatttool/gatttool.py
@@ -400,7 +400,7 @@ class GATTToolBackend(BLEBackend):
         log.info("Removed bonds for %s", address)
 
     def _disconnect(self, event):
-        if self._auto_reconnect:
+        if self._connected_device is not None and self._auto_reconnect:
             # this is called as a callback from the pexpect thread
             # the reconnection process has to be started in parallel, otherwise
             # the call is never finished

--- a/pygatt/backends/gatttool/gatttool.py
+++ b/pygatt/backends/gatttool/gatttool.py
@@ -23,6 +23,8 @@ from pygatt.backends import BLEBackend, Characteristic, BLEAddressType
 from pygatt.backends.backend import DEFAULT_CONNECT_TIMEOUT_S
 from .device import GATTToolBLEDevice
 
+DEFAULT_RECONNECT_DELAY = 1.0
+
 log = logging.getLogger(__name__)
 
 if hasattr(bytes, 'fromhex'):
@@ -199,6 +201,8 @@ class GATTToolBackend(BLEBackend):
         self._running = threading.Event()
         self._address = None
         self._send_lock = threading.Lock()
+        self._auto_reconnect = False
+        self._reconnecting = False
 
     def sendline(self, command):
         """
@@ -357,10 +361,11 @@ class GATTToolBackend(BLEBackend):
         return []
 
     def connect(self, address, timeout=DEFAULT_CONNECT_TIMEOUT_S,
-                address_type=BLEAddressType.public):
+                address_type=BLEAddressType.public, auto_reconnect=False):
         log.info('Connecting to %s with timeout=%s', address, timeout)
         self.sendline('sec-level low')
         self._address = address
+        self._auto_reconnect = auto_reconnect
 
         try:
             cmd = 'connect {0} {1}'.format(self._address, address_type.name)
@@ -395,13 +400,42 @@ class GATTToolBackend(BLEBackend):
         log.info("Removed bonds for %s", address)
 
     def _disconnect(self, event):
-        try:
-            self.disconnect(self._connected_device)
-        except NotConnectedError:
-            pass
+        if self._auto_reconnect:
+            #this is called as a callback from the pexpect thread
+            #the reconnection process has to be started in parallel, otherwise
+            #the call is never finished
+            log.info("Connection to %s lost. Reconnecting...", self._address)
+            reconnect_thread = threading.Thread(target=self.reconnect,
+                                                args=(self._connected_device, ))
+            reconnect_thread.start()
+        else:
+            try:
+                self.disconnect(self._connected_device)
+            except NotConnectedError:
+                pass
+
+    @at_most_one_device
+    def reconnect(self, timeout=DEFAULT_CONNECT_TIMEOUT_S):
+        while self._auto_reconnect:
+            log.info("Connecting to %s with timeout=%s", self._address,
+                        timeout)
+            try:
+                cmd = "connect"
+                with self._receiver.event("connect", timeout):
+                    self.sendline(cmd)
+                self._connected_device.resubscribe_all() # reenable all notifications
+                log.info("Connection to %s reestablished.")
+                break # finished reconnecting
+            except NotificationTimeout:
+                message = ("Timed out connecting to {0} after {1} seconds. "
+                           "Retrying in {2} seconds".format(
+                                self._address, timeout, DEFAULT_RECONNECT_DELAY))
+                log.info(message)
+                time.sleep(DEFAULT_RECONNECT_DELAY)
 
     @at_most_one_device
     def disconnect(self, *args, **kwargs):
+        self._auto_reconnect = False  # disables any running reconnection
         if not self._receiver.is_set("disconnected"):
             self.sendline('disconnect')
         self._connected_device = None

--- a/tests/gatttool/test_backend.py
+++ b/tests/gatttool/test_backend.py
@@ -63,6 +63,35 @@ class GATTToolBackendTests(unittest.TestCase):
         time.sleep(0.1)
         ok_(device._backend.reconnect.called)
 
+    def test_no_reconnect_default(self):
+        # Just keep saying we got the "Disconnected" response
+        def rate_limited_expect_d(*args, **kwargs):
+            time.sleep(0.001)
+            # hard code the "Disconnected" event
+            return 1
+
+        address = "11:22:33:44:55:66"
+        device = self.backend.connect(address)
+        device._backend.reconnect = MagicMock()
+        self.spawn.return_value.expect.side_effect = rate_limited_expect_d
+        time.sleep(0.1)
+        ok_(not device._backend.reconnect.called)
+
+    def test_no_reconnect_disconnect(self):
+        # Just keep saying we got the "Disconnected" response
+        def rate_limited_expect_d(*args, **kwargs):
+            time.sleep(0.001)
+            # hard code the "Disconnected" event
+            return 1
+
+        address = "11:22:33:44:55:66"
+        device = self.backend.connect(address, auto_reconnect=True)
+        device._backend.reconnect = MagicMock()
+        device.disconnect()
+        self.spawn.return_value.expect.side_effect = rate_limited_expect_d
+        time.sleep(0.1)
+        ok_(not device._backend.reconnect.called)
+
     def test_auto_reconnect(self):
         # Just keep saying we got the "Disconnected" response
         def rate_limited_expect_d(*args, **kwargs):

--- a/tests/gatttool/test_backend.py
+++ b/tests/gatttool/test_backend.py
@@ -49,6 +49,42 @@ class GATTToolBackendTests(unittest.TestCase):
         device = self.backend.connect(address)
         ok_(device is not None)
 
+    def test_auto_reconnect_call(self):
+        # Just keep saying we got the "Disconnected" response
+        def rate_limited_expect_d(*args, **kwargs):
+            time.sleep(0.001)
+            # hard code the "Disconnected" event
+            return 1
+
+        address = "11:22:33:44:55:66"
+        device = self.backend.connect(address, auto_reconnect=True)
+        device._backend.reconnect = MagicMock()
+        self.spawn.return_value.expect.side_effect = rate_limited_expect_d
+        time.sleep(0.1)
+        ok_(device._backend.reconnect.called)
+
+    def test_auto_reconnect(self):
+        # Just keep saying we got the "Disconnected" response
+        def rate_limited_expect_d(*args, **kwargs):
+            time.sleep(0.001)
+            # hard code the "Disconnected" event
+            return 1
+
+        # Just keep saying we got the "Connected" response
+        def rate_limited_expect_c(*args, **kwargs):
+            time.sleep(0.001)
+            # hard code the "Connected" event
+            return 3
+
+        address = "11:22:33:44:55:66"
+        device = self.backend.connect(address, auto_reconnect=True)
+        self.spawn.return_value.expect.side_effect = rate_limited_expect_d
+        time.sleep(0.1)
+        device.resubscribe_all = MagicMock()
+        self.spawn.return_value.expect.side_effect = rate_limited_expect_c
+        time.sleep(0.1)
+        ok_(device.resubscribe_all.called)
+
     def test_single_byte_notification(self):
         event = {
             'after': "Notification handle = 0x0024 value: 64".encode("utf8")


### PR DESCRIPTION
I recreated this pull request as I requested it from the master branch last time.

When flag is set, the gatttool backend will try to reestablish
the connection to the device on a connection loss.
Once the connection is reestablished, notifications for all previously
subscribed uuids will be automatically reenabled.