### PR TITLE
Parameterize timeout in characteristics discovery

### DIFF
--- a/pygatt/backends/gatttool/device.py
+++ b/pygatt/backends/gatttool/device.py
@@ -53,6 +53,6 @@ class GATTToolBLEDevice(BLEDevice):
         self._connected = False
 
     @connection_required
-    def discover_characteristics(self):
-        self._characteristics = self._backend.discover_characteristics(self)
+    def discover_characteristics(self, *args, **kwargs):
+        self._characteristics = self._backend.discover_characteristics(self, *args, **kwargs)
         return self._characteristics

--- a/pygatt/backends/gatttool/gatttool.py
+++ b/pygatt/backends/gatttool/gatttool.py
@@ -430,7 +430,7 @@ class GATTToolBackend(BLEBackend):
             pass
 
     @at_most_one_device
-    def discover_characteristics(self):
+    def discover_characteristics(self, timeout=5):
         self._characteristics = {}
         self._receiver.register_callback(
             "discover",
@@ -438,7 +438,7 @@ class GATTToolBackend(BLEBackend):
         )
         self.sendline('characteristics')
 
-        max_time = time.time() + 5
+        max_time = time.time() + timeout
         while not self._characteristics and time.time() < max_time:
             time.sleep(.5)
 


### PR DESCRIPTION
Really this only solves 1/2 the problem as this code can be entered
through other methods in which passing this parameter is not practical.
The best solution is to provide a timing vector on/shortly after object
creation this way all timing paramaters can be tuned once.