### PR TITLE
bgapi discovery improvements

### DIFF
--- a/pygatt/backends/bgapi/bgapi.py
+++ b/pygatt/backends/bgapi/bgapi.py
@@ -142,7 +142,7 @@ class BGAPIBackend(BLEBackend):
         Raises a NotConnectedError if the device cannot connect after 10
         attempts, with a short pause in between each attempt.
         """
-        for attempt in range(MAX_RECONNECTION_ATTEMPTS):
+        for _ in range(MAX_RECONNECTION_ATTEMPTS):
             try:
                 serial_port = self._serial_port or self._detect_device_port()
                 self._ser = None
@@ -158,9 +158,6 @@ class BGAPIBackend(BLEBackend):
                     serial_exception) as e:
                 if self._ser:
                     self._ser.close()
-                elif attempt == 0:
-                    raise NotConnectedError(
-                        "No BGAPI compatible device detected: %s" % e)
                 self._ser = None
                 time.sleep(0.25)
         else:
@@ -189,9 +186,7 @@ class BGAPIBackend(BLEBackend):
         self._ser.flush()
         self._ser.close()
 
-        # Give the USB adapter some time to restart. Else the connection
-        # to the adapter may fail and cause the following _open_serial_port call
-        # to fail.
+        # Give the USB adapter some time to restart.
         time.sleep(0.5)
 
         self._open_serial_port()

--- a/pygatt/backends/bgapi/bgapi.py
+++ b/pygatt/backends/bgapi/bgapi.py
@@ -155,12 +155,12 @@ class BGAPIBackend(BLEBackend):
                 self._ser.read()
                 break
             except (BGAPIError, serial.serialutil.SerialException,
-                    serial_exception):
+                    serial_exception) as e:
                 if self._ser:
                     self._ser.close()
                 elif attempt == 0:
                     raise NotConnectedError(
-                        "No BGAPI compatible device detected")
+                        "No BGAPI compatible device detected: %s" % e)
                 self._ser = None
                 time.sleep(0.25)
         else:

--- a/pygatt/backends/bgapi/bgapi.py
+++ b/pygatt/backends/bgapi/bgapi.py
@@ -147,8 +147,8 @@ class BGAPIBackend(BLEBackend):
                 serial_port = self._serial_port or self._detect_device_port()
                 self._ser = None
 
-                log.debug("Attempting to connect to serial port after "
-                          "restarting device")
+                log.debug("Attempting to connect to serial port %s after "
+                          "restarting device" % serial_port)
                 self._ser = serial.Serial(serial_port, baudrate=115200,
                                           timeout=0.25)
                 # Wait until we can actually read from the device

--- a/pygatt/backends/bgapi/bgapi.py
+++ b/pygatt/backends/bgapi/bgapi.py
@@ -147,8 +147,7 @@ class BGAPIBackend(BLEBackend):
                 serial_port = self._serial_port or self._detect_device_port()
                 self._ser = None
 
-                log.debug("Attempting to connect to serial port %s after "
-                          "restarting device" % serial_port)
+                log.debug("Attempting to connect to serial port %s." % serial_port)
                 self._ser = serial.Serial(serial_port, baudrate=115200,
                                           timeout=0.25)
                 # Wait until we can actually read from the device
@@ -162,8 +161,7 @@ class BGAPIBackend(BLEBackend):
                 log.debug("Connection attempt failed: %s" % e)
                 time.sleep(0.25)
         else:
-            raise NotConnectedError("Unable to reconnect with USB "
-                                    "device after rebooting")
+            raise NotConnectedError("Unable to connect to USB device.")
 
     def start(self):
         """
@@ -183,6 +181,7 @@ class BGAPIBackend(BLEBackend):
 
         # The zero param just means we want to do a normal restart instead of
         # starting a firmware update restart.
+        log.debug("Rebooting USB device.")
         self.send_command(CommandBuilder.system_reset(0))
         self._ser.flush()
         self._ser.close()

--- a/pygatt/backends/bgapi/bgapi.py
+++ b/pygatt/backends/bgapi/bgapi.py
@@ -189,6 +189,11 @@ class BGAPIBackend(BLEBackend):
         self._ser.flush()
         self._ser.close()
 
+        # Give the USB adapter some time to restart. Else the connection
+        # to the adapter may fail and cause the following _open_serial_port call
+        # to fail.
+        time.sleep(0.5)
+
         self._open_serial_port()
         self._receiver = threading.Thread(target=self._receive)
         self._receiver.daemon = True

--- a/pygatt/backends/bgapi/bgapi.py
+++ b/pygatt/backends/bgapi/bgapi.py
@@ -159,6 +159,7 @@ class BGAPIBackend(BLEBackend):
                 if self._ser:
                     self._ser.close()
                 self._ser = None
+                log.debug("Connection attempt failed: %s" % e)
                 time.sleep(0.25)
         else:
             raise NotConnectedError("Unable to reconnect with USB "

--- a/pygatt/backends/bgapi/bgapi.py
+++ b/pygatt/backends/bgapi/bgapi.py
@@ -147,7 +147,8 @@ class BGAPIBackend(BLEBackend):
                 serial_port = self._serial_port or self._detect_device_port()
                 self._ser = None
 
-                log.debug("Attempting to connect to serial port %s." % serial_port)
+                log.debug("Attempting to connect to serial port %s." %
+                          serial_port)
                 self._ser = serial.Serial(serial_port, baudrate=115200,
                                           timeout=0.25)
                 # Wait until we can actually read from the device


### PR DESCRIPTION
This pull request primarily addresses #118. On some setups it is necessary to wait for a short moment after restarting the USB adapter and or retry a few times before it can be talked to again. Otherwise the `_open_serial_port` call will fail and abort with "No BGAPI compatible device detected".

**Implemented changes:**
* Wait half a second after restarting the USB adapter
* Revert 9ac2bf9 to not abort after the first connection attempt anymore. Even with a delay after restarting it may still fail otherwise.
* Add the actual observed exception to the "No BGAPI compatible device detected" error print so that the user can tell what happened
* Clarify some of the connection establishment debug prints to make it more clear what is happening.

**Testing the changes:**
* Use the bgapi backend. See for example [the minimal setup in the README](https://github.com/peplin/pygatt#example-use). On an affected setup the `adapter.start()` will fail without the changes in this branch.
* Run the example without an adapter connected to see an  exception notice printed in addition to the hardcoded error message.

Note that I am not too familiar with pygatt beyond my debugging. So I have not run any other tests other than using this branch on my setup.