### PR TITLE
Clarify Python requirement in README and recommend the latest version.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,11 @@ Requirements
 ------------
 
 -  Python 2.7
+
+   -  The latest version is recommended. Earlier versions (for example
+      2.7.3) will not connect to the USB adapter at all and fail during
+      ``struct.unpack`` calls.
+
 -  BlueZ 5.18 or greater (with gatttool) - required for the gatttool
    backend only.
 


### PR DESCRIPTION
I have seen two older Python versions (2.7 and 2.7.3) which fail to talk
to the USB adapter at all. They break during struct.unpack calls. The
latest versions 2.7.12 and 2.7.13 work fine though. I am not quite sure
which the lowest supported version is, so recommending the latest seems
a good compromise.

I'm happy for suggestions on how to phrase this best. I do think it is worth mentioning though in the README as we spent a bit of time looking into this issue before figuring out what the problem was.