### PR TITLE
Add window size parameter to GATTToolBackend.

### DIFF
--- a/pygatt/backends/gatttool/gatttool.py
+++ b/pygatt/backends/gatttool/gatttool.py
@@ -186,13 +186,15 @@ class GATTToolBackend(BLEBackend):
     """
 
     def __init__(self, hci_device='hci0', gatttool_logfile=None,
-                 cli_options=None):
+                 cli_options=None, search_window_size=None):
         """
         Initialize.
 
         hci_device -- the hci_device to use with GATTTool.
         gatttool_logfile -- an optional filename to store raw gatttool
                 input and output.
+        search_window_size -- integer (optional); size in bytes of the
+                search window that is used by `pexpect.expect`
         """
 
         if is_windows():
@@ -209,6 +211,7 @@ class GATTToolBackend(BLEBackend):
         self._running = threading.Event()
         self._address = None
         self._send_lock = threading.Lock()
+        self._search_window_size = search_window_size
 
     def sendline(self, command):
         """
@@ -252,7 +255,8 @@ class GATTToolBackend(BLEBackend):
         ]
         gatttool_cmd = ' '.join([arg for arg in args if arg])
         log.debug('gatttool_cmd=%s', gatttool_cmd)
-        self._con = pexpect.spawn(gatttool_cmd, logfile=self._gatttool_logfile)
+        self._con = pexpect.spawn(gatttool_cmd, logfile=self._gatttool_logfile,
+                                  searchwindowsize=self._search_window_size)
 
         # Wait for the interactive prompt
         self._con.expect(r'\[LE\]>', timeout=initialization_timeout)


### PR DESCRIPTION
**Problem:** When sending many small packets, I was seeing CPU usage gradually go up and latency gradually increase. This is for a remote control application where latency is fairly critical.

By monitoring the pexpect log, I noticed that gatttool was echoing incoming char-write-cmd input before actually sending them. It looks like this causes the next pexpect call to have to wade through an increasingly large window of gatttool prompts.

**Fix:** Allow the client to pass in a window size for pexpect. This means that pexpect only looks at the last N bytes of the output (though still proving the full buffer after firing an event).

I currently use this with `search_window_size=200`; this completely eliminates the gradually-increasing lag I experienced earlier.