### PR TITLE
Use enum-compat instead of enum34 directly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     url='https://github.com/peplin/pygatt',
     install_requires=[
         'pyserial',
-        'enum34'
+        'enum-compat'
     ],
     setup_requires=[
         'coverage >= 3.7.1',


### PR DESCRIPTION
Hi,

I'm getting an error in Home Assistant running python 3.6 that uses your library: `AttributeError: module 'enum' has no attribute 'IntFlag'`

It appears enum34 is not meant to be installed in Python versions 3.4+
so this fixes it.

Let me know what you think,