### PR TITLE
Fix uneffective BGAPI device open retry mechanism

### DIFF
--- a/pygatt/backends/bgapi/bgapi.py
+++ b/pygatt/backends/bgapi/bgapi.py
@@ -158,7 +158,7 @@ class BGAPIBackend(BLEBackend):
                     serial_exception):
                 if self._ser:
                     self._ser.close()
-                elif attempt == 0:
+                elif attempt == (MAX_RECONNECTION_ATTEMPTS - 1):
                     raise NotConnectedError(
                         "No BGAPI compatible device detected")
                 self._ser = None


### PR DESCRIPTION
Commit 2b6c2e4007be9b63e58d51101bd8aaca46093674 already introduced a retry mechanism on serial port open, in order to allow the device to boot after a reboot command.

Unfortunately it didn't work properly: only one attempt was made due to a wrong comparison causing an early break out of the retry loop.

This patch fixes the said bug.

Signed-off-by: Andrea Merello <andrea.merello@gmail.com>