### PR TITLE
Initialize logging by default to avoid spurious warnings.

### DIFF
--- a/pygatt/__init__.py
+++ b/pygatt/__init__.py
@@ -1,3 +1,14 @@
+import logging
+
+
+class NullHandler(logging.Handler):
+    def emit(self, record):
+        pass
+
+# Initialize a null handler for logging to avoid printing spurious "No handlers
+# could be found for logger" messages.
+logging.getLogger(__name__).addHandler(NullHandler())
+
 from .exceptions import BLEError  # noqa
 from .device import BLEDevice  # noqa
 from .backends import BGAPIBackend, GATTToolBackend, BLEAddressType  # noqa


### PR DESCRIPTION
This adds a default "null handler" to the logging module, so when
clients using PyGATT do not explicitly initialize debug logging, they
don't get spurious "no handlers found for logger" messages.

Fixes #141