### PR TITLE
Fix BGAPI automatic connection retries after reset.

### DIFF
--- a/tests/serial_mock.py
+++ b/tests/serial_mock.py
@@ -4,6 +4,8 @@ try:
 except ImportError:
     import Queue as queue
 
+from mock import MagicMock
+
 
 class SerialMock(object):
     """
@@ -23,8 +25,7 @@ class SerialMock(object):
     def close(self):
         self._isOpen = False
 
-    def write(self, input_data):
-        pass
+    write = MagicMock()
 
     def flush(self):
         pass


### PR DESCRIPTION
This fixes faulty logic in the BGAPI initialization that cause the
automatic connection retry logic to fail in some environments.

Fixes #133 