### PR TITLE
Officially mark Python 3.6 as supported, enable unit testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: python
 sudo: false
 python:
-- '3.5'
+  - '2.7'
+  - '3.4'
+  - '3.5'
+  - '3.6'
 cache:
   directories:
   - "$HOME/.cache/pip"
   - ".tox"
-install:
-- pip install tox
+install: pip install tox-travis
 script: tox --recreate
 deploy:
   provider: pypi

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,11 @@
 Release History
 ================
 
+V3.2.1
+------
+
+- Improvement: Officially support Python 3.6.
+
 V3.2.0
 ------
 

--- a/README.rst
+++ b/README.rst
@@ -23,11 +23,10 @@ leaves something to be desired and only works in Linux.
 Requirements
 ------------
 
--  Python 2.7
+-  Python 2.7.5 or greater, or Python 3.5 or greater
 
-   -  The latest version is recommended. Earlier versions (for example
-      2.7.3) will not connect to the USB adapter at all and fail during
-      ``struct.unpack`` calls.
+   -  Python 2.7.3's ``struct`` library has a bug that will break PyGATT - 2.7.5
+         or greater is recommended.
 
 -  BlueZ 5.18 or greater (with gatttool) - required for the gatttool
    backend only.

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,9 @@
 
 [tox]
 envlist = py27
+          py34
           py35
+          py36
 
 [testenv]
 sitepackages=False
@@ -16,4 +18,4 @@ deps = -r{toxinidir}/requirements.txt
 
 [flake8]
 max-line-length = 80
-exclude=*.egg,.eggs,.tox,./lib,./bin,./env,./env3.5
+exclude=*.egg,.eggs,.tox,./lib,./bin,./env,./env3.5,./env3.4,./env3.6


### PR DESCRIPTION
No code changes required (besides #131, which is already in v3.2) - but this enables unit testing against Python 3.6, so we can say it's "officially" supported.