### PR TITLE
Fix uneffective BGAPI device open retry mechanism

### DIFF
--- a/pygatt/backends/bgapi/bgapi.py
+++ b/pygatt/backends/bgapi/bgapi.py
@@ -166,7 +166,7 @@ class BGAPIBackend(BLEBackend):
                 log.debug("Failed to open serial port", exc_info=True)
                 if self._ser:
                     self._ser.close()
-                elif attempt == 0:
+                elif attempt == (max_connection_attempts - 1):
                     raise NotConnectedError(
                         "No BGAPI compatible device detected")
                 self._ser = None


### PR DESCRIPTION
Actually you have merged #144 but apparently it did not fix the reconnection problem I've tried to fix in #133 . 

#144 does implement a logic that cause the retry not to happen on the first connection attempt, but just on the reconnections after reset, which is fine, but the reconnection mechanism itself seems still broken to me.

This is a respin of #133 that should fix the reconnection mechanism  on the top of the new reconnection logic merged in #144