### PR TITLE
Fix characteristic write does not work here

### DIFF
--- a/pygatt/backends/bgapi/device.py
+++ b/pygatt/backends/bgapi/device.py
@@ -115,11 +115,11 @@ class BGAPIBLEDevice(BLEDevice):
                     EventPacketType.attclient_procedure_completed)
             else:
                 self._backend.send_command(
-                    CommandBuilder.attclient_write_command(
+                    CommandBuilder.attclient_attribute_write(
                         self._handle, char_handle, value_list))
+                self._backend.expect(ResponsePacketType.attclient_attribute_write)
                 packet_type, response = self._backend.expect(
-                    ResponsePacketType.attclient_write_command)
-
+                    EventPacketType.attclient_procedure_completed)
             if (response['result'] !=
                     ErrorCode.insufficient_authentication.value):
                 # Continue to retry until we are bonded


### PR DESCRIPTION
This PR partially revert "Support of write command and request in bgapi" #115

**NOTE:** I don't know what the code is doing exaclty here, so this is mostly intended to point out the issue, rather than aim to a straightforward merge.

Since #115 characteristic write with bgapi backend is broken here. It looks like writes go nowhere; I don't see any exceptions with my current application code.

PR #115 implements an alternate code path when wait_for_response=True, that was previously not implemented but it also changes the code in case wait_for_response=False.

This commit does not touch the new code for the True case; on the other hand, in case wait_for_respose=False, we stick to the old code that here still works.
