### PR TITLE
Fix error on Windows, "No BGAPI compatible device detected"

### DIFF
--- a/pygatt/backends/bgapi/bgapi.py
+++ b/pygatt/backends/bgapi/bgapi.py
@@ -199,7 +199,7 @@ class BGAPIBackend(BLEBackend):
         self.send_command(CommandBuilder.system_reset(0))
         self._ser.flush()
         self._ser.close()
-
+#         time.sleep(0.5)
         self._open_serial_port()
         self._receiver = threading.Thread(target=self._receive)
         self._receiver.daemon = True


### PR DESCRIPTION
Fix issue #164