### PR TITLE
Scan callback

### DIFF
--- a/pygatt/backends/bgapi/bgapi.py
+++ b/pygatt/backends/bgapi/bgapi.py
@@ -306,8 +306,10 @@ class BGAPIBackend(BLEBackend):
                      frequency for advertisement packets.
         active -- True --> ask sender for scan response data. False --> don't.
         discover_mode -- one of the gap_discover_mode constants.
-        scan_cb -- This callback function is called whenever a new BLE advertising packet is received
-                   The function takes three parameters: devices, addr, packet_type
+        scan_cb -- This callback function is called whenever a new BLE 
+                   advertising packet is received.
+                   The function takes three parameters:
+                       devices, addr, packet_type
                    If the function returns True, the scan is aborted
         """
         self._scan_cb = scan_cb

--- a/pygatt/backends/bgapi/bgapi.py
+++ b/pygatt/backends/bgapi/bgapi.py
@@ -295,8 +295,8 @@ class BGAPIBackend(BLEBackend):
             self.expect(ResponsePacketType.sm_delete_bonding)
 
     def scan(self, timeout=10, scan_interval=75, scan_window=50, active=True,
-             discover_mode=constants.gap_discover_mode['observation'], scan_cb = None,
-             **kwargs):
+             discover_mode=constants.gap_discover_mode['observation'],
+             scan_cb=None, **kwargs):
         """
         Perform a scan to discover BLE devices.
 
@@ -330,15 +330,15 @@ class BGAPIBackend(BLEBackend):
         
         self._evt.set()
         start_time = time.time()
-        
+
         while self._evt.is_set():
             try:
-                self.expect(EventPacketType.gap_scan_response, timeout = timeout)
+                self.expect(EventPacketType.gap_scan_response,
+                            timeout=timeout)
             except ExpectedResponseTimeout:
                 pass
             if _timed_out(start_time, timeout):
                 break
-
 
         log.info("Stopping scan")
         self.send_command(CommandBuilder.gap_end_procedure())
@@ -739,9 +739,9 @@ class BGAPIBackend(BLEBackend):
         dev.rssi = args['rssi']
         log.debug("Received a scan response from %s with rssi=%d dBM "
                   "and data=%s", address, args['rssi'], data_dict)
-        
-        if self._scan_cb != None:
-            if self._scan_cb(self._devices_discovered, address, packet_type) == True:
+
+        if self._scan_cb is not None:
+            if self._scan_cb(self._devices_discovered, address, packet_type):
                 self._evt.clear()
 
     def _ble_evt_sm_bond_status(self, args):

--- a/pygatt/backends/bgapi/bgapi.py
+++ b/pygatt/backends/bgapi/bgapi.py
@@ -176,9 +176,6 @@ class BGAPIBackend(BLEBackend):
         else:
             raise NotConnectedError("Unable to reconnect with USB "
                                     "device after rebooting")
-            
-        if self._ser == None:
-            raise RuntimeError ("serial connection error")
 
     def start(self):
         """

--- a/pygatt/backends/bgapi/bgapi.py
+++ b/pygatt/backends/bgapi/bgapi.py
@@ -306,7 +306,7 @@ class BGAPIBackend(BLEBackend):
                      frequency for advertisement packets.
         active -- True --> ask sender for scan response data. False --> don't.
         discover_mode -- one of the gap_discover_mode constants.
-        scan_cb -- This callback function is called whenever a new BLE 
+        scan_cb -- This callback function is called whenever a new BLE
                    advertising packet is received.
                    The function takes three parameters:
                        devices, addr, packet_type
@@ -329,7 +329,7 @@ class BGAPIBackend(BLEBackend):
         self.expect(ResponsePacketType.gap_discover)
 
         log.info("Pausing for maximum %ds to allow scan to complete", timeout)
-        
+
         self._evt.set()
         start_time = time.time()
 


### PR DESCRIPTION
This pull request adds a callback to the scan method, which enables a bunch of new features:

- Abort scanning if a certain device is seen:

```
import pygatt
adapter = pygatt.BGAPIBackend()
adapter.start()
def scan_callback(devices, addr, packet_type):
    if addr == "CC:78:AB:20:8D:3A":
        return True

adapter.scan(timeout=60, scan_cb = scan_callback)
```

- Abort scanning if a device with high RSSI is near adapter:
```
import pygatt
adapter = pygatt.BGAPIBackend()
adapter.start()
def scan_callback(devices, addr, packet_type):
    if devices[addr].rssi >= -60:
        return True
adapter.scan(timeout=60, scan_cb = scan_callback)
```

- Measure advertising rate of BLE peripheral:
```
import pygatt
import time
adapter = pygatt.BGAPIBackend()
adapter.start()

class MyTimer:
    def __init__(self):
        self._timestamps = []
        
    def scan_callback(self, devices, addr, packet_type):
        if packet_type == 'connectable_advertisement_packet' and addr == "CC:78:AB:20:8D:3A":
            self._timestamps.append(time.time())        
        if len(self._timestamps) >= 10:
            return True

    def calc_advert_interval(self):
        return [x-y for x,y in zip(self._timestamps[1:], self._timestamps[:-1])]

t = MyTimer()
adapter.scan(timeout=60, scan_cb = t.scan_callback)
```


Signed-off-by: Markus Proeller <mproeller@googlemail.com>