### PR TITLE
fix #164 #179 #180

### DIFF
--- a/pygatt/backends/bgapi/bgapi.py
+++ b/pygatt/backends/bgapi/bgapi.py
@@ -166,7 +166,7 @@ class BGAPIBackend(BLEBackend):
                 log.debug("Failed to open serial port", exc_info=True)
                 if self._ser:
                     self._ser.close()
-                elif attempt == 0:
+                elif attempt >= max_connection_attempts:
                     raise NotConnectedError(
                         "No BGAPI compatible device detected")
                 self._ser = None

--- a/pygatt/backends/bgapi/bgapi.py
+++ b/pygatt/backends/bgapi/bgapi.py
@@ -166,7 +166,7 @@ class BGAPIBackend(BLEBackend):
                 log.debug("Failed to open serial port", exc_info=True)
                 if self._ser:
                     self._ser.close()
-                elif attempt >= max_connection_attempts:
+                elif attempt >= max_connection_attempts-1:
                     raise NotConnectedError(
                         "No BGAPI compatible device detected")
                 self._ser = None

--- a/pygatt/backends/bgapi/device.py
+++ b/pygatt/backends/bgapi/device.py
@@ -101,7 +101,7 @@ class BGAPIBLEDevice(BLEDevice):
         return bytearray(response['value'])
 
     @connection_required
-    def char_write_handle(self, char_handle, value, wait_for_response=False):
+    def char_write_handle(self, char_handle, value, wait_for_response=True):
 
         while True:
             value_list = [b for b in value]


### PR DESCRIPTION
For #164 and #179, this issue is caused by attempt starting from 0.
System have no chance to retry "open serial port" !
So I changed `elif attempt ==0:` to `elif attempt >= max_connection_attempts`

For #180, just for compatibility with old version like V3.1.1
Otherwise, lib user will very confuse like me why code can't work well in new Version.  