### PR TITLE
Added GATTToolBackend MTU-request

### DIFF
--- a/pygatt/backends/gatttool/device.py
+++ b/pygatt/backends/gatttool/device.py
@@ -57,3 +57,7 @@ class GATTToolBLEDevice(BLEDevice):
         self._characteristics = self._backend.discover_characteristics(
             self, *args, **kwargs)
         return self._characteristics
+
+    @connection_required
+    def exchange_mtu(self, mtu, *args, **kwargs):
+        return self._backend.exchange_mtu(self, mtu)

--- a/pygatt/backends/gatttool/gatttool.py
+++ b/pygatt/backends/gatttool/gatttool.py
@@ -101,6 +101,11 @@ class GATTToolReceiver(threading.Thread):
             'connect': {
                 'patterns': [r'Connection successful.*\[LE\]>']
             },
+            'mtu': {
+                'patterns': [
+                    r'MTU was exchanged successfully: (\d+)'
+                ]
+            }
         }
 
         for event in self._event_vector.values():
@@ -538,6 +543,24 @@ class GATTToolBackend(BLEBackend):
         rval = self._receiver.last_value("value/descriptor", "after"
                                          ).split()[1:]
         return bytearray([int(x, 16) for x in rval])
+
+    @at_most_one_device
+    def exchange_mtu(self, mtu, timeout=1):
+        cmd = 'mtu {}'.format(mtu)
+
+        log.debug('Requesting MTU: {}'.format(mtu))
+
+        with self._receiver.event('mtu', timeout=timeout):
+            self.sendline(cmd)
+        try:
+            rval = self._receiver.last_value("mtu", "after").split()[-1]
+        except ValueError:
+            log.error('MTU exchange failed: "{}"'.format(rval))
+            raise
+
+        log.debug('MTU exhange successful: {}'.format(rval))
+
+        return rval
 
     def reset(self):
         subprocess.Popen(["sudo", "systemctl", "restart", "bluetooth"]).wait()

--- a/pygatt/device.py
+++ b/pygatt/device.py
@@ -224,3 +224,11 @@ class BLEDevice(object):
             if handle in self._callbacks:
                 for callback in self._callbacks[handle]:
                     callback(handle, value)
+
+    def exchange_mtu(self, mtu):
+        """
+        ATT exchange Maximum Transmission Unit.
+        :param mtu: New MTU-value
+        :return: New MTU, as recognized by server.
+        """
+        raise NotImplementedError()


### PR DESCRIPTION
Added MTU-exchange with `Device`-member function `exchange_mtu(NEW_MTU)`. This function returns the MTU recognized by server.

```python
adapter = GATTToolBackend()
try:
  adapter.start()
  device = adapter.connect(device_id)
  
  mtu = device.exchange_mtu(64)
  print("MTU exchanged: {}".format(mtu))

except Exception as e:
  print("Exception!", repr(e))
finally
  device.disconnect()
  adapter.stop()
```