### PR TITLE
read/write characteristics with payloads greater than one MTU

### DIFF
--- a/pygatt/backends/bgapi/bgapi.py
+++ b/pygatt/backends/bgapi/bgapi.py
@@ -199,7 +199,8 @@ class BGAPIBackend(BLEBackend):
         self.send_command(CommandBuilder.system_reset(0))
         self._ser.flush()
         self._ser.close()
-
+        # ASC - needed for port to reset
+        time.sleep(0.5)
         self._open_serial_port()
         self._receiver = threading.Thread(target=self._receive)
         self._receiver.daemon = True

--- a/pygatt/backends/bgapi/device.py
+++ b/pygatt/backends/bgapi/device.py
@@ -121,7 +121,7 @@ class BGAPIBLEDevice(BLEDevice):
             all_data = len(chunk) != max_payload
 
             log.info("char_read_long chunk length= %d", len(chunk))
- 
+
         log.info("char_read_long length= %d", len(value))
 
         return value

--- a/pygatt/backends/bgapi/device.py
+++ b/pygatt/backends/bgapi/device.py
@@ -92,7 +92,7 @@ class BGAPIBLEDevice(BLEDevice):
             # then it would time out and raise an exception if allwe got was
             # the 'procedure completed' response?
             if matched_packet_type != \
-                EventPacketType.attclient_attribute_value:
+                    EventPacketType.attclient_attribute_value:
                 raise BGAPIError("Unable to read characteristic")
             if response['atthandle'] == handle:
                 # Otherwise we received a response from a wrong handle (e.g.
@@ -103,27 +103,27 @@ class BGAPIBLEDevice(BLEDevice):
 
     @connection_required
     def char_read_long(self, uuid, timeout=None):
-        
+
         max_payload = 22
-        
+
         all_data = False
-        
+
         value = bytearray()
-                
+
         while not all_data:
-            
+
             chunk = self.char_read_long_handle(
                         self.get_handle(uuid), timeout=timeout)
-            
+
             # time.sleep(0.01)
             value += chunk
-            
+
             all_data = len(chunk) != max_payload
 
             log.info("char_read_long chunk length= %d", len(chunk))
  
         log.info("char_read_long length= %d", len(value))
-        
+
         return value
 
     @connection_required
@@ -144,7 +144,7 @@ class BGAPIBLEDevice(BLEDevice):
             # then it would time out and raise an exception if allwe got was
             # the 'procedure completed' response?
             if matched_packet_type != \
-                EventPacketType.attclient_attribute_value:
+                    EventPacketType.attclient_attribute_value:
                 raise BGAPIError("Unable to read characteristic")
             if response['atthandle'] == handle:
                 # Otherwise we received a response from a wrong handle (e.g.
@@ -154,7 +154,7 @@ class BGAPIBLEDevice(BLEDevice):
         return bytearray(response['value'])
 
     @connection_required
-    def char_write_handle(self, 
+    def char_write_handle(self,
                           char_handle,
                           value,
                           wait_for_response=False):
@@ -181,8 +181,7 @@ class BGAPIBLEDevice(BLEDevice):
                 # Continue to retry until we are bonded
                 break
 
-
-    # ASC - adapted from 
+    # ASC - adapted from
     # https://raw.githubusercontent.com/mjbrown/bgapi/master/bgapi/module.py
     # - reliable_write_by_handle
     @connection_required
@@ -190,36 +189,35 @@ class BGAPIBLEDevice(BLEDevice):
                                char_handle,
                                value,
                                wait_for_response=False):
-        
+
         maxv = 18
-        
+
         for i in range(int(((len(value)-1) / maxv)+1)):
-            
+
             chunk = value[maxv*i:min(maxv*(i+1), len(value))]
             value_list = [b for b in chunk]
             # print("value_list = ", value_list)
             self._backend.send_command(
                     CommandBuilder.attclient_prepare_write(
                         self._handle, char_handle, maxv*i, value_list))
-            
+
             packet_type, response = self._backend.expect(
                                     ResponsePacketType.attclient_prepare_write)
             # print("Packet type = ", packet_type)
             # print("Response = ", response)
-            
+
             packet_type, response = self._backend.expect(
                 EventPacketType.attclient_procedure_completed)
             # print("Packet type = ", packet_type)
             # print("Response = ", response)
             time.sleep(0.1)
-            
+
         # print("Execute Write")
         time.sleep(0.1)
         # print(CommandBuilder.attclient_execute_write(self._handle, 1))
         self._backend.send_command(
             CommandBuilder.attclient_execute_write(
-                self._handle, 1)) # 1 = commit, 0 = cancel
-            # expect here?
+                self._handle, 1))  # 1 = commit, 0 = cancel
         self._backend.expect(ResponsePacketType.attclient_execute_write)
         packet_type, response = self._backend.expect(
                 EventPacketType.attclient_procedure_completed)

--- a/pygatt/backends/bgapi/device.py
+++ b/pygatt/backends/bgapi/device.py
@@ -91,7 +91,8 @@ class BGAPIBLEDevice(BLEDevice):
             # TODO why not just expect *only* the attribute value response,
             # then it would time out and raise an exception if allwe got was
             # the 'procedure completed' response?
-            if matched_packet_type != EventPacketType.attclient_attribute_value:
+            if matched_packet_type != \
+                EventPacketType.attclient_attribute_value:
                 raise BGAPIError("Unable to read characteristic")
             if response['atthandle'] == handle:
                 # Otherwise we received a response from a wrong handle (e.g.
@@ -103,7 +104,7 @@ class BGAPIBLEDevice(BLEDevice):
     @connection_required
     def char_read_long(self, uuid, timeout=None):
         
-        max_payload=22
+        max_payload = 22
         
         all_data = False
         
@@ -111,7 +112,8 @@ class BGAPIBLEDevice(BLEDevice):
                 
         while not all_data:
             
-            chunk = self.char_read_long_handle(self.get_handle(uuid), timeout=timeout)
+            chunk = self.char_read_long_handle(
+                        self.get_handle(uuid), timeout=timeout)
             
             # time.sleep(0.01)
             value += chunk
@@ -123,10 +125,6 @@ class BGAPIBLEDevice(BLEDevice):
         log.info("char_read_long length= %d", len(value))
         
         return value
-
-#        if len(value) = 
-#        for handle in uuid:
-#            return self.char_read_long_handle(self.get_handle(handle), timeout=timeout)
 
     @connection_required
     def char_read_long_handle(self, handle, timeout=None):
@@ -145,7 +143,8 @@ class BGAPIBLEDevice(BLEDevice):
             # TODO why not just expect *only* the attribute value response,
             # then it would time out and raise an exception if allwe got was
             # the 'procedure completed' response?
-            if matched_packet_type != EventPacketType.attclient_attribute_value:
+            if matched_packet_type != \
+                EventPacketType.attclient_attribute_value:
                 raise BGAPIError("Unable to read characteristic")
             if response['atthandle'] == handle:
                 # Otherwise we received a response from a wrong handle (e.g.
@@ -155,7 +154,10 @@ class BGAPIBLEDevice(BLEDevice):
         return bytearray(response['value'])
 
     @connection_required
-    def char_write_handle(self, char_handle, value, wait_for_response=False):
+    def char_write_handle(self, 
+                          char_handle,
+                          value,
+                          wait_for_response=False):
 
         while True:
             value_list = [b for b in value]
@@ -180,44 +182,49 @@ class BGAPIBLEDevice(BLEDevice):
                 break
 
 
-    #ASC - adapted from https://raw.githubusercontent.com/mjbrown/bgapi/master/bgapi/module.py - reliable_write_by_handle
+    # ASC - adapted from 
+    # https://raw.githubusercontent.com/mjbrown/bgapi/master/bgapi/module.py
+    # - reliable_write_by_handle
     @connection_required
-    def char_write_long_handle(self, char_handle, value, wait_for_response=False):
+    def char_write_long_handle(self,
+                               char_handle,
+                               value,
+                               wait_for_response=False):
         
-        maxv=18
+        maxv = 18
         
         for i in range(int(((len(value)-1) / maxv)+1)):
             
             chunk = value[maxv*i:min(maxv*(i+1), len(value))]
             value_list = [b for b in chunk]
-            #print("value_list = ", value_list)
+            # print("value_list = ", value_list)
             self._backend.send_command(
                     CommandBuilder.attclient_prepare_write(
                         self._handle, char_handle, maxv*i, value_list))
             
-            packet_type, response = self._backend.expect(ResponsePacketType.attclient_prepare_write)
-            #print("Packet type = ", packet_type)
-            #print("Response = ", response)
+            packet_type, response = self._backend.expect(
+                                    ResponsePacketType.attclient_prepare_write)
+            # print("Packet type = ", packet_type)
+            # print("Response = ", response)
             
             packet_type, response = self._backend.expect(
                 EventPacketType.attclient_procedure_completed)
-            #print("Packet type = ", packet_type)
-            #print("Response = ", response)
+            # print("Packet type = ", packet_type)
+            # print("Response = ", response)
             time.sleep(0.1)
- #                   packet_type, response = self._backend.expect(
- #                       EventPacketType.attclient_procedure_completed)
             
-        #print("Execute Write")
+        # print("Execute Write")
         time.sleep(0.1)
-        #print(CommandBuilder.attclient_execute_write(self._handle, 1))
+        # print(CommandBuilder.attclient_execute_write(self._handle, 1))
         self._backend.send_command(
-            CommandBuilder.attclient_execute_write(self._handle, 1)) # 1 = commit, 0 = cancel
-            #expect here?
+            CommandBuilder.attclient_execute_write(
+                self._handle, 1)) # 1 = commit, 0 = cancel
+            # expect here?
         self._backend.expect(ResponsePacketType.attclient_execute_write)
         packet_type, response = self._backend.expect(
                 EventPacketType.attclient_procedure_completed)
-        #print("Packet type = ", packet_type)
-        #print("Response = ", response)
+        # print("Packet type = ", packet_type)
+        # print("Response = ", response)
         time.sleep(0.1)
 
     @connection_required

--- a/pygatt/device.py
+++ b/pygatt/device.py
@@ -281,8 +281,6 @@ class BLEDevice(object):
                 for callback in self._callbacks[handle]:
                     callback(handle, value)
 
-
-
     def exchange_mtu(self, mtu):
 
         """

--- a/pygatt/device.py
+++ b/pygatt/device.py
@@ -77,6 +77,32 @@ class BLEDevice(object):
         """
         raise NotImplementedError()
 
+    def char_read_long(self, uuid):
+        """
+        Reads a Characteristic by UUID.
+
+        uuid -- UUID of Characteristic to read as a string.
+
+        Returns a bytearray containing the characteristic value on success.
+
+        Example:
+            my_ble_device.char_read('a1e8f5b1-696b-4e4c-87c6-69dfe0b0093b')
+        """
+        raise NotImplementedError()
+
+    def char_read_long_handle(self, uuid):
+        """
+        Reads a Characteristic by handle.
+
+        handle -- handle of Characteristic to read.
+
+        Returns a bytearray containing the characteristic value on success.
+
+        Example:
+            my_ble_device.char_read_handle(5)
+        """
+        raise NotImplementedError()
+
     def char_write(self, uuid, value, wait_for_response=False):
         """
         Writes a value to a given characteristic UUID.
@@ -93,6 +119,36 @@ class BLEDevice(object):
                                       wait_for_response=wait_for_response)
 
     def char_write_handle(self, handle, value, wait_for_response=False):
+        """
+        Writes a value to a given characteristic handle. This can be used to
+        write to the characteristic config handle for a primary characteristic.
+
+        hande -- the handle to write to.
+        value -- a bytearray to write to the characteristic.
+        wait_for_response -- wait for response after writing.
+
+        Example:
+            my_ble_device.char_write(42,
+                                     bytearray([0x00, 0xFF]))
+        """
+        raise NotImplementedError()
+
+    def char_write_long(self, uuid, value, wait_for_response=False):
+        """
+        Writes a value to a given characteristic UUID.
+
+        uuid -- the UUID of the characteristic to write to.
+        value -- a bytearray to write to the characteristic.
+        wait_for_response -- wait for response after writing.
+
+        Example:
+            my_ble_device.char_write('a1e8f5b1-696b-4e4c-87c6-69dfe0b0093b',
+                                     bytearray([0x00, 0xFF]))
+        """
+        return self.char_write_long_handle(self.get_handle(uuid), value,
+                                           wait_for_response=wait_for_response)
+
+    def char_write_long_handle(self, handle, value, wait_for_response=False):
         """
         Writes a value to a given characteristic handle. This can be used to
         write to the characteristic config handle for a primary characteristic.
@@ -224,3 +280,19 @@ class BLEDevice(object):
             if handle in self._callbacks:
                 for callback in self._callbacks[handle]:
                     callback(handle, value)
+
+
+
+    def exchange_mtu(self, mtu):
+
+        """
+
+        ATT exchange Maximum Transmission Unit.
+
+        :param mtu: New MTU-value
+
+        :return: New MTU, as recognized by server.
+
+        """
+
+        raise NotImplementedError()


### PR DESCRIPTION
For the project I am working on, there is a need for the ability to read/write in the region of 256 bytes of data from/to a characteristic. I have implemented a long read and long write to do this.

Note that the device being communicated with will have to support this functionality.


Additionally, I have fixed a bug (which occurs under Windows) by adding a small delay before opening a serial port (bgapi.py).
