### PR TITLE
Use attribute write by default, not command

### DIFF
--- a/pygatt/backends/bgapi/device.py
+++ b/pygatt/backends/bgapi/device.py
@@ -133,9 +133,10 @@ class BGAPIBLEDevice(BLEDevice):
         return bytearray(response)
 
     @connection_required
-    def char_write_handle(self, char_handle, value, wait_for_response=False):
+    def char_write_handle(self, char_handle, value, wait_for_response=True):
         while True:
             value_list = [b for b in value]
+            # An "attribute write" is always acknowledged by the remote host.
             if wait_for_response:
                 self._backend.send_command(
                     CommandBuilder.attclient_attribute_write(
@@ -144,6 +145,8 @@ class BGAPIBLEDevice(BLEDevice):
                     ResponsePacketType.attclient_attribute_write)
                 packet_type, response = self._backend.expect(
                     EventPacketType.attclient_procedure_completed)
+
+            # A "command" write is unacknowledged - don't wait for a response.
             else:
                 self._backend.send_command(
                     CommandBuilder.attclient_write_command(

--- a/pygatt/backends/gatttool/gatttool.py
+++ b/pygatt/backends/gatttool/gatttool.py
@@ -549,13 +549,16 @@ class GATTToolBackend(BLEBackend):
             self._connected_device.receive_notification(handle, values)
 
     @at_most_one_device
-    def char_write_handle(self, handle, value, wait_for_response=False,
+    def char_write_handle(self, handle, value, wait_for_response=True,
                           timeout=1):
         """
         Writes a value to a given characteristic handle.
+
         :param handle:
         :param value:
-        :param wait_for_response:
+        :param wait_for_response: If true, performs an attribute write. If
+            false, sends a command and expects no acknowledgement from the
+            device.
         """
         cmd = 'char-write-{0} 0x{1:02x} {2}'.format(
             'req' if wait_for_response else 'cmd',

--- a/pygatt/device.py
+++ b/pygatt/device.py
@@ -104,13 +104,15 @@ class BLEDevice(object):
         """
         raise NotImplementedError()
 
-    def char_write(self, uuid, value, wait_for_response=False):
+    def char_write(self, uuid, value, wait_for_response=True):
         """
         Writes a value to a given characteristic UUID.
 
         uuid -- the UUID of the characteristic to write to.
         value -- a bytearray to write to the characteristic.
-        wait_for_response -- wait for response after writing.
+        wait_for_response -- wait for response after writing. A GATT "command"
+            is used when not waiting for a response. The remote host will not
+            acknowledge the write.
 
         Example:
             my_ble_device.char_write('a1e8f5b1-696b-4e4c-87c6-69dfe0b0093b',
@@ -119,7 +121,7 @@ class BLEDevice(object):
         return self.char_write_handle(self.get_handle(uuid), value,
                                       wait_for_response=wait_for_response)
 
-    def char_write_handle(self, handle, value, wait_for_response=False):
+    def char_write_handle(self, handle, value, wait_for_response=True):
         """
         Writes a value to a given characteristic handle. This can be used to
         write to the characteristic config handle for a primary characteristic.
@@ -129,8 +131,7 @@ class BLEDevice(object):
         wait_for_response -- wait for response after writing.
 
         Example:
-            my_ble_device.char_write(42,
-                                     bytearray([0x00, 0xFF]))
+            my_ble_device.char_write_handle(42, bytearray([0x00, 0xFF]))
         """
         raise NotImplementedError()
 


### PR DESCRIPTION
Most writes to characteristics are attribute writes, where an ACK is
expected. Make that the default to avoid confusion. This was the default
in earlier versions of pygatt before PR #115 landed.