### PR TITLE
Extend timeout for attribute write ACK

### DIFF
--- a/pygatt/backends/bgapi/device.py
+++ b/pygatt/backends/bgapi/device.py
@@ -144,7 +144,10 @@ class BGAPIBLEDevice(BLEDevice):
                 self._backend.expect(
                     ResponsePacketType.attclient_attribute_write)
                 packet_type, response = self._backend.expect(
-                    EventPacketType.attclient_procedure_completed)
+                    EventPacketType.attclient_procedure_completed,
+                    # According to the BLE spec, the device has 30 seconds to
+                    # repsonse to the attribute write.
+                    timeout=30)
 
             # A "command" write is unacknowledged - don't wait for a response.
             else:

--- a/pygatt/backends/gatttool/gatttool.py
+++ b/pygatt/backends/gatttool/gatttool.py
@@ -550,7 +550,7 @@ class GATTToolBackend(BLEBackend):
 
     @at_most_one_device
     def char_write_handle(self, handle, value, wait_for_response=True,
-                          timeout=1):
+                          timeout=30):
         """
         Writes a value to a given characteristic handle.
 


### PR DESCRIPTION
The spec says the device has 30 seconds. This fixes an issue on a real
device, whereas I otherwise did not get the ACK.