### PR TITLE
Fix GATTTOOL backend handling of indiciations

### DIFF
--- a/pygatt/backends/gatttool/gatttool.py
+++ b/pygatt/backends/gatttool/gatttool.py
@@ -537,7 +537,7 @@ class GATTToolBackend(BLEBackend):
             log.warn("Blank message received in notification, ignored")
             return
 
-        match_obj = re.match(r'Notification handle = (0x[0-9a-f]+) value:(.*)',
+        match_obj = re.match(r'.* handle = (0x[0-9a-f]+) value:(.*)',
                              msg.decode('utf-8'))
         if match_obj is None:
             log.warn("Unable to parse notification string, ignoring: %s", msg)

--- a/tests/gatttool/test_backend.py
+++ b/tests/gatttool/test_backend.py
@@ -188,3 +188,15 @@ class GATTToolBackendTests(unittest.TestCase):
         device.receive_notification = MagicMock()
         device._backend._handle_notification_string(event)
         ok_(not device.receive_notification.called)
+
+    def test_indication(self):
+        event = {
+            'after': "Indication   handle = 0x0024 value: 64".encode("utf8")
+        }
+        address = "11:22:33:44:55:66"
+        device = self.backend.connect(address)
+        device.receive_notification = MagicMock()
+        device._backend._handle_notification_string(event)
+        ok_(device.receive_notification.called)
+        eq_(0x24, device.receive_notification.call_args[0][0])
+        eq_(bytearray([0x64]), device.receive_notification.call_args[0][1])


### PR DESCRIPTION
The new regex was too strict, and did not recognize the "Indication"
response from gatttool. I confirmed with a unit test that it was
broken, and this fixes the bug.

Fixes #231