### PR TITLE
Multiple fixes

### DIFF
--- a/pygatt/backends/gatttool/gatttool.py
+++ b/pygatt/backends/gatttool/gatttool.py
@@ -426,7 +426,7 @@ class GATTToolBackend(BLEBackend):
     def clear_bond(self, address=None):
         """Use the 'bluetoothctl' program to erase a stored BLE bond.
         """
-        con = pexpect.spawn('sudo bluetoothctl')
+        con = pexpect.spawn('bluetoothctl')
 
         try:
             con.expect("bluetooth", timeout=1)

--- a/pygatt/backends/gatttool/gatttool.py
+++ b/pygatt/backends/gatttool/gatttool.py
@@ -78,6 +78,7 @@ class GATTToolReceiver(threading.Thread):
             'char_written': {
                 'patterns': [
                     r'Characteristic value (was )?written successfully',
+                    r'Characteristic Write Request failed: A timeout occured',
                 ]
             },
             'value': {

--- a/pygatt/backends/gatttool/gatttool.py
+++ b/pygatt/backends/gatttool/gatttool.py
@@ -538,14 +538,14 @@ class GATTToolBackend(BLEBackend):
             log.warn("Blank message received in notification, ignored")
             return
 
-        match_obj = re.match(r'Notification handle = (0x[0-9a-f]+) value:(.*)',
+        match_obj = re.match(r'(Notification|Indication  ) handle = (0x[0-9a-f]+) value:(.*)',
                              msg.decode('utf-8'))
         if match_obj is None:
             log.warn("Unable to parse notification string, ignoring: %s", msg)
             return
 
-        handle = int(match_obj.group(1), 16)
-        values = _hex_value_parser(match_obj.group(2).strip())
+        handle = int(match_obj.group(2), 16)
+        values = _hex_value_parser(match_obj.group(3).strip())
         if self._connected_device is not None:
             self._connected_device.receive_notification(handle, values)
 

--- a/pygatt/device.py
+++ b/pygatt/device.py
@@ -215,7 +215,7 @@ class BLEDevice(object):
                 self.char_write_handle(
                     characteristic_config_handle,
                     properties,
-                    wait_for_response=False
+                    wait_for_response=True
                 )
                 log.info("Subscribed to uuid=%s", uuid)
                 self._subscribed_handlers[value_handle] = properties
@@ -243,7 +243,7 @@ class BLEDevice(object):
                 self.char_write_handle(
                     characteristic_config_handle,
                     properties,
-                    wait_for_response=False
+                    wait_for_response=True
                 )
                 log.info("Unsubscribed from uuid=%s", uuid)
             else:
@@ -315,6 +315,6 @@ class BLEDevice(object):
                 self.char_write_handle(
                     characteristic_config_handle,
                     properties,
-                    wait_for_response=False
+                    wait_for_response=True
                 )
                 log.info("Resubscribed to uuid=%s", uuid)


### PR DESCRIPTION
A couple small hot fixes.

* Now supports handling indications, previously would ignore them.
* Not supports error responses, previously would not see them and time out with an exception.
* Does not call `sudo bluetoothctl` for removing a bonding; that caused the process to hang and was not necessary for the feature to work.
* When subscribing, issues a write request, not a command. Subscribing was not working otherwise on my test device. YMMV - I haven't checked the BLE spec.