### PR TITLE
Added subscribe_handle() and unsubscribe_handle()

### DIFF
--- a/pygatt/device.py
+++ b/pygatt/device.py
@@ -254,7 +254,8 @@ class BLEDevice(object):
                 log.debug("Already unsubscribed from uuid=%s", uuid)
 
     def subscribe_handle(self, handle, callback=None, indication=False,
-                  wait_for_response=True):
+                         wait_for_response=True):
+
         """
         Like subscribe() but using handle instead of uuid.
 
@@ -306,7 +307,10 @@ class BLEDevice(object):
                 )
                 log.info("Unsubscribed from handle=0x%04x", value_handle)
             else:
-                log.debug("Already unsubscribed from handle=0x%04x", value_handle)
+                log.debug(
+                    "Already unsubscribed from handle=0x%04x",
+                    value_handle
+                )
 
     def get_handle(self, char_uuid):
         """


### PR DESCRIPTION
In the original pygatt, it only provided `subscribe()` and `unsubscribe()` which accept a UUID as the parameter.

In `subscribe()`, it will get the handle by the `uuid` parameter. This procedure is not always successful. But when I directly provide the handle of the characteristic, the problem can be solved.

So I simply added two method to `BLEDevice` class. They are `subscribe_handle()` and `unsubscribe_handle()`.