### PR TITLE
RFC: Service discovery and characteristic permissions

### DIFF
--- a/pygatt/backends/__init__.py
+++ b/pygatt/backends/__init__.py
@@ -1,3 +1,3 @@
-from .backend import BLEBackend, Characteristic, BLEAddressType  # noqa
+from .backend import BLEBackend, Characteristic, Service, BLEAddressType  # noqa
 from .bgapi.bgapi import BGAPIBackend  # noqa
 from .gatttool.gatttool import GATTToolBackend  # noqa

--- a/pygatt/backends/backend.py
+++ b/pygatt/backends/backend.py
@@ -67,12 +67,13 @@ class Characteristic(object):
     Only valid for the lifespan of a BLE connection, since the handle values are
     dynamic.
     """
-    def __init__(self, uuid, handle):
+    def __init__(self, uuid, handle, properties = 0):
         """
         Sets the characteritic uuid and handle.
 
         handle - a bytearray
         """
+        self.properties = properties
         self.uuid = uuid
         self.handle = handle
         self.descriptors = {

--- a/pygatt/backends/backend.py
+++ b/pygatt/backends/backend.py
@@ -88,3 +88,25 @@ class Characteristic(object):
     def __str__(self):
         return "<%s uuid=%s handle=%d>" % (self.__class__.__name__,
                                            self.uuid, self.handle)
+
+class Service(object):
+    """
+    A GATT service, including its max and min handle values.
+    Only valid for the lifespan of a BLE connection, since the handle values are
+    dynamic.
+    """
+
+    def __init__(self, uuid, handle_min, handle_max):
+        """
+        Sets the service uuid and handle range
+
+        handle_max, handle_min - bytearrays
+        """
+        self.uuid = uuid
+        self.handle_min = handle_min
+        self.handle_max = handle_max
+
+    def __str__(self):
+        return "<%s uuid=%s handle_min=%d handle_max=%d>" % (
+            self.__class__.__name__,
+            self.handle_min, self.handle_max)

--- a/pygatt/backends/bgapi/bgapi.py
+++ b/pygatt/backends/bgapi/bgapi.py
@@ -710,12 +710,14 @@ class BGAPIBackend(BLEBackend):
         log.debug("attribute type = %x", args['type'])
         log.debug("attribute value = 0x%s", hexlify(bytearray(args['value'])))
 
-        properties, value_handle = struct.unpack("<BH", bytearray(args['value'])[:3])
-
-        cs = self._characteristics[args['connection_handle']]
-        for uuid in cs:
-            if cs[uuid].handle == value_handle:
-                cs[uuid].properties = properties
+        # we use read by type only for characteristic declaration, otherwise
+        # we would have to check for type uuid to be 0x2803
+        if args['type'] == 3:
+            properties, value_handle = struct.unpack("<BH", bytearray(args['value'])[:3])
+            cs = self._characteristics[args['connection_handle']]
+            for uuid in cs:
+                if cs[uuid].handle == value_handle:
+                    cs[uuid].properties = properties
 
     def _ble_evt_attclient_group_found(self, args):
         raw_uuid = bytearray(reversed(args['uuid']))

--- a/pygatt/backends/bgapi/device.py
+++ b/pygatt/backends/bgapi/device.py
@@ -212,3 +212,8 @@ class BGAPIBLEDevice(BLEDevice):
         self._characteristics = self._backend.discover_characteristics(
             self._handle)
         return self._characteristics
+
+    @connection_required
+    def discover_primary_services(self):
+        self._services = self._backend.discover_primary_services(self._handle)
+        return self._services


### PR DESCRIPTION
Hi!

Disclaimer: I open this PR to see if we can discuss a bit on this, indeed I don't expect it to be ready for merge yet..

Context: I'm working on a demo application written with Kivy (that should work on both Linux PCs and android devices) that scans and explores BLE devices (similar to those APPs you can find on google play market); on Linux PC platform I use pygatt for communicating with BLE.

While I found easy to get tree view of services and characteristics with android APIs, I couldn't do this with pygatt: I could only get a flat list of characteristics, but I didn't found a way to get a clue about primary services.. So my first commit in this PR adds a method to enumerate primary services. I match them with child characteristics by checking for handles numeric order outside pygatt, but maybe there is some better way to do this..

The other thing that I didn't find a way to achieve with pygatt is to detect the characteristics permissions (i.e. which could be read, which could be written, which can be subscribed for notifications, etc..). My second patch in this PR tries to add this information to the characteristics objects; it reads the characteristic declarations attributes from BLE after discovering the characteristics.

One of the problem I faced doing this, is that, while inquiring for the characteristic declarations, I got the same events flavour used also for regular characteristic reads, so I tried to workaround on this in my 3rd patch, but, again there might be better way for achieving my goal..

Indeed even if I have had already putted my hand a bit in pygatt code, I'm not very familiar with its design (and I'm mostly an embedded, low-level, C software guy), so any comment would be extremely appreciated..

Oh, I'm working on bluegiga dongles, but I would like to expand this also to the gatttool wrapper in future...

Thanks,
Andrea