### PR TITLE
Fix the incorrect handle conversion for char_read_handle

### DIFF
--- a/pygatt/backends/gatttool/gatttool.py
+++ b/pygatt/backends/gatttool/gatttool.py
@@ -604,7 +604,7 @@ class GATTToolBackend(BLEBackend):
         :rtype: bytearray
         """
         with self._receiver.event("value/descriptor", timeout=timeout):
-            self.sendline('char-read-hnd %s' % handle)
+            self.sendline('char-read-hnd 0x{0:02x}'.format(handle))
         rval = self._receiver.last_value("value/descriptor", "after"
                                          ).split()[1:]
         return bytearray([int(x, 16) for x in rval])


### PR DESCRIPTION
The handle value is sending in as int, since the get_handle() and
char_write_handle() are expecging the int and convert to hex while
sending to gatttool.

Formating it as %s will lead to incorrect handle to be used and might
end up with reading the wrong handle.