### PR TITLE
Add functools.wraps to BGAPI decorator

### DIFF
--- a/pygatt/backends/bgapi/device.py
+++ b/pygatt/backends/bgapi/device.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import time
 
@@ -15,6 +16,7 @@ def connection_required(func):
     """Raise an exception if the device is not connected before calling the
     actual function.
     """
+    @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
         if self._handle is None:
             raise exceptions.NotConnectedError()


### PR DESCRIPTION
We had this on the gatttool backend, but not bgapi. Using this preserves
the docstring of the original method.

Fixes #256