### PR TITLE
Allow one or no space before carriage return in a gatttool response

### DIFF
--- a/pygatt/backends/gatttool/gatttool.py
+++ b/pygatt/backends/gatttool/gatttool.py
@@ -85,7 +85,7 @@ class GATTToolReceiver(threading.Thread):
                 'patterns': [r'value: .*? \r']
             },
             'value/descriptor': {
-                'patterns': [r'value/descriptor: .*? \r']
+                'patterns': [r'value/descriptor: .*? ?\r']
             },
             'discover': {
                 'patterns': [


### PR DESCRIPTION
This makes the regexp slightly more permissive to account for what must
be different output in different versions or platforms.

Fixes #257