### PR TITLE
Fix loop over a mutable dict during BGAPI shutdown

### DIFF
--- a/pygatt/backends/bgapi/bgapi.py
+++ b/pygatt/backends/bgapi/bgapi.py
@@ -245,7 +245,11 @@ class BGAPIBackend(BLEBackend):
         self.expect(ResponsePacketType.system_address_get)
 
     def stop(self):
-        for device in self._connections.values():
+        # Stash the connected devices before iterating and disconnecting,
+        # because devices are removed from _connections when disconnection
+        # events are received from the adapter.
+        connected_devices = list(self._connections.values())
+        for device in connected_devices:
             try:
                 device.disconnect()
             except NotConnectedError:


### PR DESCRIPTION
This fixes a RuntimeError reported in #306.

There's a circular dependency between the backend and device classes.
When stopping the BGAPI backend, we call `disconnect` on each device.
When a disconnection event is received from the BLED112 adapter, the
device is removed from `self._connections` - the same dict we are
iterating over.