### PR TITLE
Pin package versions to avoid upstream surprises

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 
 flake8==2.1.0
 pylint==1.2.1
-coverage>=3.7.1
-nose>=1.3.6
-mock>=1.1.2
-funcsigs>=0.4
+coverage==5.5
+nose==1.3.7
+mock==3.0.5
+funcsigs==1.0.2

--- a/setup.py
+++ b/setup.py
@@ -1,49 +1,43 @@
-__title__ = 'pygatt'
-__version__ = '4.0.5'
-__license__ = 'Apache License, Version 2.0 and MIT License'
-__copyright__ = 'Copyright 2015 Stratos Inc. and Orion Labs'
+__title__ = "pygatt"
+__version__ = "4.0.5"
+__license__ = "Apache License, Version 2.0 and MIT License"
+__copyright__ = "Copyright 2015 Stratos Inc. and Orion Labs"
 
 try:
     from setuptools import setup, find_packages
 except ImportError:
     from distutils.core import setup  # pylint: disable=F0401,E0611
 
-with open('README.rst') as f:
+with open("README.rst") as f:
     readme = f.read()
-with open('CHANGELOG.rst') as f:
+with open("CHANGELOG.rst") as f:
     changelog = f.read()
 
 setup(
     name=__title__,
     version=__version__,
-    description='Python Bluetooth LE (Low Energy) and GATT Library',
-    author='Chris Peplin <github@rhubarbtech.com>',
-    author_email='github@rhubarbtech.com',
+    description="Python Bluetooth LE (Low Energy) and GATT Library",
+    author="Chris Peplin <github@rhubarbtech.com>",
+    author_email="github@rhubarbtech.com",
     packages=find_packages(exclude=("tests", "tests.*")),
-    package_data={'': ['LICENSE']},
+    package_data={"": ["LICENSE"]},
     license="Apache 2.0 and MIT",
-    long_description=readme + '\n\n' + changelog,
-    url='https://github.com/peplin/pygatt',
-    install_requires=[
-        'pyserial',
-        'enum-compat'
-    ],
-    setup_requires=[
-        'coverage >= 3.7.1',
-        'nose >= 1.3.7'
-    ],
+    long_description=readme + "\n\n" + changelog,
+    url="https://github.com/peplin/pygatt",
+    install_requires=["pyserial", "enum-compat"],
+    setup_requires=["coverage == 5.5", "nose == 1.3.7"],
     extras_require={
-        'GATTTOOL': ["pexpect"],
+        "GATTTOOL": ["pexpect"],
     },
-    package_dir={'pygatt': 'pygatt'},
+    package_dir={"pygatt": "pygatt"},
     zip_safe=False,
     include_package_data=True,
     classifiers=(
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-    )
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+    ),
 )


### PR DESCRIPTION
The latest `coverage` version (6.x beta) was being pulled in
automatically, but it drops support for Python 2.7. Pin all version to
avoid any surprises in the future.